### PR TITLE
keymap_switch fixes

### DIFF
--- a/keymap_switch/init.lua
+++ b/keymap_switch/init.lua
@@ -104,7 +104,7 @@ local function get_current_keymap()
 
     for line in fd:lines() do
         if line:match("xkb_symbols") then
-            local keymap = line:match("\+.*\+")
+            local keymap = line:match('%+[%w]*%+')
 
             fd:close()
             if not keymap then


### PR DESCRIPTION
Hi!
`\+` is invalid escape sequence, use `%+` instead.
See [Lua patterns](http://lua-users.org/wiki/PatternsTutorial) at lua-users wiki.

Best regards
