### PR TITLE
Fixed Vim modeline

### DIFF
--- a/basic_mpd/init.lua
+++ b/basic_mpd/init.lua
@@ -150,4 +150,5 @@ function set_unknown(unknown)
 end
 
 setmetatable(_M, { __call = function () return widget end })
--- vim: filetype=lua:expandtab:shiftwidth=8:tabstop=8:softtabstop=8:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=8:sw=8:sts=8:tw=80:fenc=utf-8:et

--- a/battery/init.lua
+++ b/battery/init.lua
@@ -262,3 +262,5 @@ setmetatable(_M, { __call = function ()
     lib.hooks.timer.start(update)
     return widget
 end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/bluetooth/init.lua
+++ b/bluetooth/init.lua
@@ -90,3 +90,5 @@ lib.hooks.timer.register(60, 300, update)
 lib.hooks.timer.start(update)
 
 setmetatable(_M, { __call = function () return widget end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/clock/init.lua
+++ b/clock/init.lua
@@ -220,3 +220,5 @@ setmetatable(_M, { __call = function ()
 
     return widget
 end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/cpu/init.lua
+++ b/cpu/init.lua
@@ -83,4 +83,5 @@ local function get_data_source()
 end
 
 setmetatable(_M, { __call = function (_, ...) return get_data_source(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/fs_usage/init.lua
+++ b/fs_usage/init.lua
@@ -52,4 +52,5 @@ local function get_data_source(path)
 end
 
 setmetatable(_M, { __call = function (_, ...) return get_data_source(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/gps/init.lua
+++ b/gps/init.lua
@@ -187,3 +187,5 @@ lib.hooks.timer.register(60, 300, update)
 lib.hooks.timer.start(update)
 
 setmetatable(_M, { __call = function () return widget end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/init.lua
+++ b/init.lua
@@ -22,3 +22,5 @@ require("obvious.temp_info")
 require("obvious.keymap_switch")
 
 module("obvious")
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/io/init.lua
+++ b/io/init.lua
@@ -98,4 +98,5 @@ local function get_data_source(device)
 end
 
 setmetatable(_M, { __call = function (_, ...) return get_data_source(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/keymap_switch/init.lua
+++ b/keymap_switch/init.lua
@@ -141,4 +141,5 @@ function update()
 end
 
 setmetatable(_M, { __call = function() return init(settings.widget) end }) -- TODO let the user specify widget here
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/hooks/init.lua
+++ b/lib/hooks/init.lua
@@ -155,4 +155,4 @@ function timer.has(fn)
     end
 end
 
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -10,4 +10,5 @@ require("obvious.lib.widget")
 require("obvious.lib.wlan")
 
 module("obvious.lib")
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/markup.lua
+++ b/lib/markup.lua
@@ -84,4 +84,4 @@ function fg.urgent(text) return fg.color(beautiful.fg_urgent, text) end
 function bg.urgent(text) return bg.color(beautiful.bg_urgent, text) end
 function    urgent(text) return bg.urgent(fg.urgent(text))   end
 
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/mpd/init.lua
+++ b/lib/mpd/init.lua
@@ -209,4 +209,4 @@ function MPD:toggle_play()
     end
 end
 
--- vim:filetype=lua:tabstop=8:shiftwidth=4:expandtab:
+-- vim:ft=lua:ts=8:sw=4:sts=2:tw=80:fenc=utf-8:et

--- a/lib/widget/graph.lua
+++ b/lib/widget/graph.lua
@@ -54,4 +54,5 @@ function create(data, layout)
 end
 
 setmetatable(_M, { __call = function (_, ...) return graph(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=8:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/widget/init.lua
+++ b/lib/widget/init.lua
@@ -83,4 +83,4 @@ function from_data_source(data)
     return ret
 end
 
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=8:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/widget/progressbar.lua
+++ b/lib/widget/progressbar.lua
@@ -45,4 +45,5 @@ function create(data, layout)
 end
 
 setmetatable(_M, { __call = function (_, ...) return progressbar(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=8:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/widget/textbox.lua
+++ b/lib/widget/textbox.lua
@@ -44,4 +44,4 @@ function create(data, layout)
     return obj
 end
 
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=8:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/lib/wlan.lua
+++ b/lib/wlan.lua
@@ -125,3 +125,5 @@ local function get_info(device)
 end
 
 setmetatable(_M, { __call = function (_, ...) return get_data(...) end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/loadavg/init.lua
+++ b/loadavg/init.lua
@@ -89,3 +89,5 @@ setmetatable(_M, { __call = function ()
 
     return widget
 end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/mem/init.lua
+++ b/mem/init.lua
@@ -73,4 +73,5 @@ local function get_data_source()
 end
 
 setmetatable(_M, { __call = function (_, ...) return get_data_source(...) end })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/net/init.lua
+++ b/net/init.lua
@@ -77,4 +77,4 @@ function send(device)
     return data(device, "send")
 end
 
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/popup_run_prompt/init.lua
+++ b/popup_run_prompt/init.lua
@@ -261,3 +261,4 @@ function set_cache(c)
     settings.cache = c or defaults.cache
 end
 
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/temp_info/init.lua
+++ b/temp_info/init.lua
@@ -54,4 +54,4 @@ setmetatable(_M, { __call = function ()
    return widget
 end })
 
--- vim: filetype=lua:expandtab:shiftwidth=3:tabstop=3:softtabstop=3:encoding=utf-8:textwidth=80
+-- vim:ft=lua:ts=3:sw=3:sts=3:tw=80:fenc=utf-8:et

--- a/umts/init.lua
+++ b/umts/init.lua
@@ -103,3 +103,5 @@ lib.hooks.timer.register(60, 300, update)
 lib.hooks.timer.start(update)
 
 setmetatable(_M, { __call = function () return widget end })
+
+-- vim:ft=lua:ts=8:sw=2:sts=2:tw=80:fenc=utf-8:et

--- a/volume_alsa/init.lua
+++ b/volume_alsa/init.lua
@@ -142,4 +142,5 @@ local function create(_, cardid, channel, abrv)
 end
 
 setmetatable(_M, { __call = create })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et

--- a/volume_freebsd/init.lua
+++ b/volume_freebsd/init.lua
@@ -112,4 +112,5 @@ local function create(_, channel)
 end
 
 setmetatable(_M, { __call = create })
--- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=4:softtabstop=4:encoding=utf-8:textwidth=80
+
+-- vim:ft=lua:ts=4:sw=4:sts=4:tw=80:fenc=utf-8:et


### PR DESCRIPTION
Hi!

`encoding` is not allowed in a Vim modeline.

`encoding` (`enc`) http://vimdoc.sourceforge.net/htmldoc/options.html#'fileencoding'

> Sets the character encoding used inside Vim.
> It applies to text in the buffers, registers, Strings in expressions, text stored in the viminfo file, etc.

`fileencoding` (`fenc`) http://vimdoc.sourceforge.net/htmldoc/options.html#'encoding'

> Sets the character encoding for the file of this buffer.
> When 'fileencoding' is different from 'encoding', conversion will be done when writing the file.

Also see screenshot:
![2014-02-11-221101_1280x1024_scrot](https://f.cloud.github.com/assets/1256298/2140259/d3088f82-9349-11e3-9a8d-4d291b5f5274.png)

What I did:
- Replaced  `encoding` by `fileencoding`
- Added modeline where there is no added
- Used a shorter version of modeline that fits in 80 characters

Best regards
