### PR TITLE
battery.backends: Set LC_ALL=C in popen()

### DIFF
--- a/battery/backends.lua
+++ b/battery/backends.lua
@@ -17,7 +17,7 @@ local unpack       = unpack
 local backend = {}
 
 local function popen(cmd)
-  return iopopen('LANG=C ' .. cmd .. ' 2>/dev/null')
+  return iopopen('LC_ALL=C LANG=C ' .. cmd .. ' 2>/dev/null')
 end
 
 function backend:clone(clone)

--- a/tests/battery.lua
+++ b/tests/battery.lua
@@ -441,24 +441,24 @@ local sformat  = string.format
 local ac_state = 'charged'
 
 local function remove_environment(command, ...)
-	local vars = {}
-	for _, v in ipairs{...} do
-		vars[v] = true
-	end
+  local vars = {}
+  for _, v in ipairs{...} do
+    vars[v] = true
+  end
 
-	local other_vars = ''
-	
-	while true do
-		command, count = command:gsub("^(([%w_]+=%S+)%s+)", function(full, env)
-			if not vars[env] then
-				other_vars = other_vars .. full
-			end
-			return ''
-		end)
-		if count == 0 then break end
-	end
+  local other_vars = ''
+  
+  while true do
+    command, count = command:gsub("^(([%w_]+=%S+)%s+)", function(full, env)
+      if not vars[env] then
+        other_vars = other_vars .. full
+      end
+      return ''
+    end)
+    if count == 0 then break end
+  end
 
-	return other_vars .. command
+  return other_vars .. command
 end
 
 local function mock_popen(command)

--- a/tests/battery.lua
+++ b/tests/battery.lua
@@ -440,12 +440,29 @@ local sformat  = string.format
 
 local ac_state = 'charged'
 
-local function mock_popen(command)
-  local lang_c_match = smatch(command, '^LANG=C%s+(.*)')
+local function remove_environment(command, ...)
+	local vars = {}
+	for _, v in ipairs{...} do
+		vars[v] = true
+	end
 
-  if lang_c_match then
-    command = lang_c_match
-  end
+	local other_vars = ''
+	
+	while true do
+		command, count = command:gsub("^(([%w_]+=%S+)%s+)", function(full, env)
+			if not vars[env] then
+				other_vars = other_vars .. full
+			end
+			return ''
+		end)
+		if count == 0 then break end
+	end
+
+	return other_vars .. command
+end
+
+local function mock_popen(command)
+  command = remove_environment(command, 'LANG=C', 'LC_ALL=C')
 
   local stderr_redirect_match = smatch(command, '^(.-)%s*2>/dev/null$')
 


### PR DESCRIPTION
It seems that setting just LANG=C is not enough on some systems with (weird) custom locale settings (like mine) to force backends to format numbers with decimal dot instead of comma, so LC_ALL=C has to be set too.

Also, changed the test module to match the main module changes (mock_popen() handles commands both with and without LC_ALL=C in them now).