### PR TITLE
wlan: accept "auto" as an alias for the first available WLAN

### DIFF
--- a/lib/wlan.lua
+++ b/lib/wlan.lua
@@ -88,7 +88,9 @@ local function find_first_wlan_openbsd()
   local device = nil
 
   local fd = io.popen("/sbin/ifconfig " .. device)
-  if not fd then return 0 end
+  if not fd then
+    return
+  end
 
   for line in fd:lines() do
     local m = line:match("^(%w+): ")

--- a/lib/wlan.lua
+++ b/lib/wlan.lua
@@ -85,9 +85,10 @@ local function get_data_openbsd(device)
 end
 
 local function find_first_wlan_openbsd()
-  local device = nil
+  local last_device = nil
+  local wlan_device = nil
 
-  local fd = io.popen("/sbin/ifconfig " .. device)
+  local fd = io.popen("/sbin/ifconfig")
   if not fd then
     return
   end
@@ -95,10 +96,11 @@ local function find_first_wlan_openbsd()
   for line in fd:lines() do
     local m = line:match("^(%w+): ")
     if m then
-      device = m
+      last_device = m
     else
       m = line:match("%s+ieee80211: ")
-      if m and device then
+      if m and last_device then
+        wlan_device = last_device
         break
       end
     end
@@ -106,7 +108,7 @@ local function find_first_wlan_openbsd()
 
   fd:close()
 
-  return device
+  return wlan_device
 end
 
 local function get_data_linux(device)

--- a/lib/wlan.lua
+++ b/lib/wlan.lua
@@ -152,7 +152,7 @@ local function find_first_wlan_linux()
   return device
 end
 
-local function find_first_wlan()
+function find_first_wlan()
   if first_wlan then
     return first_wlan
   end
@@ -182,8 +182,6 @@ local function get_info(device)
   end
   return ""
 end
-
-_M.find_first_wlan = find_first_wlan
 
 setmetatable(_M, { __call = function (_, ...) return get_data(...) end })
 

--- a/wlan/init.lua
+++ b/wlan/init.lua
@@ -36,7 +36,12 @@ function format_percent(link)
 end
 
 local function get_data_source(device)
-  local device = device or "wlan0"
+  local device = device
+  if device == "auto" then
+    device = lib.wlan.find_first_wlan()
+  end
+  device = device or "wlan0"
+
   local data = {}
 
   data.device = device

--- a/wlan/readme
+++ b/wlan/readme
@@ -2,7 +2,7 @@ WLAN widget
 
 This widget monitors your WLAN's signal strength. To set the device it monitors, use
     obvious.wlan.set_device(dev)
-The default is "wlan0".
+The default is "wlan0". Specify "auto" to use the first available WLAN in your system.
 
 To add it to your rc.lua, include
     require("obvious.wlan")


### PR DESCRIPTION
If "auto" is specified as the device name, then the first WLAN in the system is chosen.

This may help those who want to use a single (possibly version-controlled) configuration on multiple machines with [predictable network interface names](http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/) enabled.