### PR TITLE
Update volume_alsa to lua 5.3 without /module/ function

### DIFF
--- a/volume_alsa/init.lua
+++ b/volume_alsa/init.lua
@@ -24,7 +24,7 @@ local lib = {
   markup = require("obvious.lib.markup")
 }
 
-module("obvious.volume_alsa")
+local volume_alsa = {}
 
 local objects = { }
 
@@ -141,6 +141,6 @@ local function create(_, cardid, channel, abrv)
   return widget
 end
 
-setmetatable(_M, { __call = create })
+return setmetatable(volume_alsa, { __call = create })
 
 -- vim:ft=lua:ts=2:sw=2:sts=2:tw=80:et


### PR DESCRIPTION
Hi,

I've updated the `volume_alsa` widget to work on Debian-based distros (for builds without `LUA_COMPAT_MODULE`). See #36 .

Tested on Ubuntu 18.04.

Would you be interested in merging it?